### PR TITLE
fix: harden adversarial evasion detection

### DIFF
--- a/.github/workflows/test_adversarial_evasion.yml
+++ b/.github/workflows/test_adversarial_evasion.yml
@@ -196,8 +196,13 @@ jobs:
           echo "verify.outcome=${{ steps.verify.outcome }}"
           echo "ci_ready=${{ matrix.ci_ready }}"
           echo "require_failure=${{ matrix.require_failure }}"
-          nonconforming="$(grep -ci 'whitelisted:[[:space:]]*NonConforming' ./exceptions.log 2>/dev/null || echo 0)"
-          unknown="$(grep -ci 'whitelisted:[[:space:]]*Unknown' ./exceptions.log 2>/dev/null || echo 0)"
+          to_int() {
+            raw="$(printf '%s' "${1:-}" | tr -cd '0-9')"
+            [[ -n "$raw" ]] || raw="0"
+            printf '%s' "$raw"
+          }
+          nonconforming="$(to_int "$(grep -ci 'whitelisted:[[:space:]]*NonConforming' ./exceptions.log 2>/dev/null || true)")"
+          unknown="$(to_int "$(grep -ci 'whitelisted:[[:space:]]*Unknown' ./exceptions.log 2>/dev/null || true)")"
           echo "exceptions.nonconforming=$nonconforming"
           echo "exceptions.unknown=$unknown"
 

--- a/.github/workflows/test_adversarial_evasion.yml
+++ b/.github/workflows/test_adversarial_evasion.yml
@@ -114,13 +114,14 @@ jobs:
         with:
           create_custom_whitelists: true
           include_process_in_whitelist: ${{ matrix.include_process }}
-          custom_whitelists_path: ./custom_whitelist.json
+          # The action runs from $HOME; use an absolute path for consistency.
+          custom_whitelists_path: ${{ github.workspace }}/custom_whitelist.json
 
       - name: Apply baseline custom whitelist
         uses: ./
         with:
           set_custom_whitelists: true
-          custom_whitelists_path: ./custom_whitelist.json
+          custom_whitelists_path: ${{ github.workspace }}/custom_whitelist.json
 
       - name: Verify custom whitelist is active
         run: |

--- a/.github/workflows/test_adversarial_evasion.yml
+++ b/.github/workflows/test_adversarial_evasion.yml
@@ -92,6 +92,10 @@ jobs:
           disconnected_mode: true
           network_scan: true
           packet_capture: true
+          # Keep this workflow deterministic: enforce violations at verification time,
+          # not during background capture.
+          check_blacklist: false
+          check_anomalous: false
           whitelist: github_ubuntu
 
       - name: Prepare Python
@@ -118,6 +122,22 @@ jobs:
           set_custom_whitelists: true
           custom_whitelists_path: ./custom_whitelist.json
 
+      - name: Verify custom whitelist is active
+        run: |
+          endpoint_count="$(jq '[.whitelists[]? | select(.name == "custom_whitelist") | .endpoints? // [] | length] | add // 0' ./custom_whitelist.json 2>/dev/null || echo 0)"
+          echo "custom_whitelist endpoint_count=$endpoint_count"
+          if [[ "$endpoint_count" -le 0 ]]; then
+            echo "Baseline custom whitelist is empty; refusing to run adversarial scenario."
+            exit 1
+          fi
+
+          active="$($EDAMAME_POSTURE_CMD get-whitelist-name 2>/dev/null || echo unknown)"
+          echo "active_whitelist=$active"
+          if [[ "$active" != "custom_whitelist" ]]; then
+            echo "Custom whitelist was not loaded into the daemon."
+            exit 1
+          fi
+
       - name: Execute adversarial scenario
         run: |
           jq -r --arg s "${{ matrix.scenario }}" '.scenarios[] | select(.id == $s) | .command' \
@@ -140,11 +160,34 @@ jobs:
       - name: Collect exceptions for diagnostics
         if: always()
         run: |
-          $EDAMAME_POSTURE_CMD get-exceptions > ./exceptions.log 2>&1 || true
+          # Exceptions can be populated asynchronously; retry briefly for deterministic evidence capture.
+          for i in {1..8}; do
+            $EDAMAME_POSTURE_CMD get-exceptions > ./exceptions.log 2>&1 || true
+            if grep -qi 'whitelisted:' ./exceptions.log 2>/dev/null; then
+              break
+            fi
+            sleep 2
+          done
           echo "Exceptions summary"
           echo "  NonConforming: $(grep -ci 'whitelisted:[[:space:]]*NonConforming' ./exceptions.log || echo 0)"
           echo "  Unknown: $(grep -ci 'whitelisted:[[:space:]]*Unknown' ./exceptions.log || echo 0)"
           echo "  Anomalous strings: $(grep -ci 'anomalous' ./exceptions.log || echo 0)"
+
+      - name: Collect sessions for diagnostics
+        if: always()
+        run: |
+          $EDAMAME_POSTURE_CMD get-sessions > ./sessions.log 2>&1 || true
+
+      - name: Upload evidence artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: adversarial-${{ matrix.scenario }}-${{ github.run_id }}
+          path: |
+            ./custom_whitelist.json
+            ./payload.sh
+            ./exceptions.log
+            ./sessions.log
 
       - name: Gate core scenario
         if: always()
@@ -153,10 +196,19 @@ jobs:
           echo "verify.outcome=${{ steps.verify.outcome }}"
           echo "ci_ready=${{ matrix.ci_ready }}"
           echo "require_failure=${{ matrix.require_failure }}"
+          nonconforming="$(grep -ci 'whitelisted:[[:space:]]*NonConforming' ./exceptions.log 2>/dev/null || echo 0)"
+          unknown="$(grep -ci 'whitelisted:[[:space:]]*Unknown' ./exceptions.log 2>/dev/null || echo 0)"
+          echo "exceptions.nonconforming=$nonconforming"
+          echo "exceptions.unknown=$unknown"
 
           if [[ "${{ matrix.ci_ready }}" != "true" ]]; then
             echo "Non-CI-ready scenario: not gating."
             exit 0
+          fi
+
+          if [[ "${STRICT_MODE}" == "true" && "${{ matrix.require_failure }}" == "true" && $((nonconforming + unknown)) -le 0 ]]; then
+            echo "Expected whitelist exceptions in strict mode but none were captured."
+            exit 1
           fi
 
           if [[ "${STRICT_MODE}" == "true" && "${{ matrix.require_failure }}" == "true" && "${{ steps.verify.outcome }}" != "failure" ]]; then

--- a/action.yml
+++ b/action.yml
@@ -3579,24 +3579,45 @@ runs:
           fi
           
           if [[ -n "${{ inputs.custom_whitelists_path }}" ]]; then
-            # Save to the specified file
-            $CREATE_CMD > "${{ inputs.custom_whitelists_path }}"
-            
-            # Check if the created whitelist has endpoints
-            if command -v jq &> /dev/null; then
-              ENDPOINT_COUNT=$(jq '[.whitelists[]? | select(.name == "custom_whitelist") | .endpoints? // [] | length] | add // 0' "${{ inputs.custom_whitelists_path }}" 2>/dev/null || echo "0")
-              echo "Created whitelist contains $ENDPOINT_COUNT endpoints"
-              
-              if [[ "$ENDPOINT_COUNT" -eq 0 ]]; then
-                echo "[WARNING]  Warning: Created whitelist is empty (no endpoints)"
-                echo "This can happen if:"
-                echo "  - No network sessions were captured yet (wait longer before creating whitelist)"
-                echo "  - Only ingress (local-to-local) sessions exist (these are excluded from whitelists)"
-                echo "  - All sessions were filtered out"
-                echo "The whitelist file was created but will not be loaded automatically if empty"
+            # Create-custom-whitelists relies on a cache that is populated by get-sessions.
+            # In CI, sessions/exceptions can lag behind traffic generation, so we flush and retry.
+            $EDAMAME_POSTURE_CMD get-sessions > /dev/null 2>&1 || true
+
+            attempt=1
+            max_attempts=5
+            ENDPOINT_COUNT=0
+            while [[ "$attempt" -le "$max_attempts" ]]; do
+              echo "Creating custom whitelists (attempt $attempt/$max_attempts)..."
+              $CREATE_CMD > "${{ inputs.custom_whitelists_path }}"
+
+              if command -v jq &> /dev/null; then
+                ENDPOINT_COUNT=$(jq '[.whitelists[]? | select(.name == "custom_whitelist") | .endpoints? // [] | length] | add // 0' "${{ inputs.custom_whitelists_path }}" 2>/dev/null || echo "0")
+                echo "Created whitelist contains $ENDPOINT_COUNT endpoints"
+                if [[ "$ENDPOINT_COUNT" -gt 0 ]]; then
+                  break
+                fi
+              else
+                echo "[WARNING]  Warning: jq not available, cannot verify endpoint count"
+                break
               fi
+
+              attempt=$((attempt + 1))
+              if [[ "$attempt" -le "$max_attempts" ]]; then
+                echo "[INFO] No endpoints yet; waiting for sessions to flush and retrying"
+                $EDAMAME_POSTURE_CMD get-sessions > /dev/null 2>&1 || true
+                sleep 5
+              fi
+            done
+
+            if command -v jq &> /dev/null && [[ "$ENDPOINT_COUNT" -eq 0 ]]; then
+              echo "[WARNING]  Warning: Created whitelist is empty (no endpoints)"
+              echo "This can happen if:"
+              echo "  - No network sessions were captured yet (wait longer before creating whitelist)"
+              echo "  - Only ingress (local-to-local) sessions exist (these are excluded from whitelists)"
+              echo "  - All sessions were filtered out"
+              echo "The whitelist file was created but will not be loaded automatically if empty"
             fi
-            
+
             echo "Custom whitelists saved to: ${{ inputs.custom_whitelists_path }}"
           else
             # Just display the whitelist JSON

--- a/tests/adversarial_scenarios.json
+++ b/tests/adversarial_scenarios.json
@@ -12,6 +12,7 @@
       "id": "allowed_domain_exfil",
       "description": "Simulate covert payload transfer over a likely approved GitHub domain/path.",
       "command": "python3 - <<'PY'\nimport base64, requests\npayload = base64.urlsafe_b64encode(b'EDAMAME_ALLOWED_DOMAIN_EXFIL_SIMULATION').decode()\nurl = f'https://github.com/search?q={payload}&type=code'\nprint('request=', url)\nresp = requests.get(url, timeout=20)\nprint('status=', resp.status_code)\nPY",
+      "signal_process": "python3",
       "learning_expected": {
         "min_nonconforming": 0,
         "min_anomalous": 0,
@@ -28,7 +29,8 @@
     {
       "id": "dns_over_https",
       "description": "Use direct DNS-over-HTTPS requests to resolvers absent from the custom whitelist.",
-      "command": "python3 - <<'PY'\nimport requests\ntargets = [\n  'https://dns.quad9.net/dns-query?name=example.com&type=A',\n  'https://dns.adguard-dns.com/dns-query?name=example.com&type=A'\n]\nfor t in targets:\n  h = {'accept': 'application/dns-json'}\n  print('request=', t)\n  r = requests.get(t, headers=h, timeout=20)\n  print('status=', r.status_code)\nPY",
+      "command": "python3 - <<'PY'\nimport requests\ntargets = [\n  'https://dns.google/resolve?name=example.com&type=A',\n  'https://cloudflare-dns.com/dns-query?name=example.com&type=A'\n]\nfor t in targets:\n  h = {'accept': 'application/dns-json'}\n  print('request=', t)\n  r = requests.get(t, headers=h, timeout=20)\n  print('status=', r.status_code)\nPY",
+      "signal_process": "python3",
       "learning_expected": {
         "min_nonconforming": 0,
         "min_anomalous": 0,
@@ -36,7 +38,7 @@
       },
       "enforcement_expected": {
         "require_failure": true,
-        "min_nonconforming": 0,
+        "min_nonconforming": 1,
         "min_anomalous": 0,
         "min_recorded_sessions": 1
       },
@@ -46,6 +48,7 @@
       "id": "cdn_piggyback",
       "description": "Access payload over public CDN endpoint not present in baseline custom whitelist.",
       "command": "python3 - <<'PY'\nimport requests\nurl = 'https://cdn.jsdelivr.net/gh/jquery/jquery@3.7.1/README.md'\nprint('request=', url)\nr = requests.get(url, timeout=20)\nprint('status=', r.status_code)\nprint('bytes=', len(r.text))\nPY",
+      "signal_process": "python3",
       "learning_expected": {
         "min_nonconforming": 0,
         "min_anomalous": 0,
@@ -53,7 +56,7 @@
       },
       "enforcement_expected": {
         "require_failure": true,
-        "min_nonconforming": 0,
+        "min_nonconforming": 1,
         "min_anomalous": 0,
         "min_recorded_sessions": 1
       },
@@ -63,6 +66,7 @@
       "id": "process_masquerade",
       "description": "Same destination reached by different process identities to validate process-aware whitelist behavior.",
       "command": "python3 - <<'PY'\nimport requests\nurl = 'https://pypi.org/pypi/requests/json'\nprint('masquerade_request=', url)\nr = requests.get(url, timeout=20)\nprint('status=', r.status_code)\nPY",
+      "signal_process": "python3",
       "learning_expected": {
         "min_nonconforming": 0,
         "min_anomalous": 0,

--- a/tests/run_adversarial_lima.sh
+++ b/tests/run_adversarial_lima.sh
@@ -118,7 +118,7 @@ start_disconnected_daemon() {
     systemctl stop edamame_posture.service >/dev/null 2>&1 || true
   fi
   $EDAMAME_POSTURE_CMD stop >/dev/null 2>&1 || true
-  pkill -f edamame_posture >/dev/null 2>&1 || true
+  pkill -x edamame_posture >/dev/null 2>&1 || true
   sleep 2
   start_output="$($EDAMAME_POSTURE_CMD background-start-disconnected \
     --network-scan \
@@ -128,7 +128,7 @@ start_disconnected_daemon() {
   if echo "$start_output" | grep -qi "unable to lock pid file"; then
     log "Detected stale pid lock; forcing cleanup and retrying startup once"
     $EDAMAME_POSTURE_CMD stop >/dev/null 2>&1 || true
-    pkill -f edamame_posture >/dev/null 2>&1 || true
+    pkill -x edamame_posture >/dev/null 2>&1 || true
     sleep 2
     $EDAMAME_POSTURE_CMD background-start-disconnected \
       --network-scan \
@@ -192,6 +192,10 @@ create_and_load_whitelist() {
   [[ "$endpoint_count" -gt 0 ]] || fail "Baseline whitelist is empty after retries for scenario=$scenario"
 
   $EDAMAME_POSTURE_CMD set-custom-whitelists-from-file "$wl_file"
+  # Make sure the test is actually exercising the custom whitelist enforcement path.
+  sleep 1
+  loaded_name="$($EDAMAME_POSTURE_CMD get-whitelist-name 2>/dev/null || echo "")"
+  [[ "$loaded_name" == "custom_whitelist" ]] || fail "Custom whitelist not active after apply (got='$loaded_name')"
 }
 
 run_scenario_payload() {
@@ -216,33 +220,82 @@ collect_and_assert() {
   local min_nonconforming
   local min_anomalous
   local min_recorded_sessions
+  local signal_process
 
   require_failure="$(jq -r --arg s "$scenario" --arg mode "$MODE" '.scenarios[] | select(.id == $s) | if $mode == "enforcement" then .enforcement_expected.require_failure // false else .learning_expected.require_failure // false end' "$SCENARIO_CONFIG")"
   min_nonconforming="$(jq -r --arg s "$scenario" --arg mode "$MODE" '.scenarios[] | select(.id == $s) | if $mode == "enforcement" then .enforcement_expected.min_nonconforming // 0 else .learning_expected.min_nonconforming // 0 end' "$SCENARIO_CONFIG")"
   min_anomalous="$(jq -r --arg s "$scenario" --arg mode "$MODE" '.scenarios[] | select(.id == $s) | if $mode == "enforcement" then .enforcement_expected.min_anomalous // 0 else .learning_expected.min_anomalous // 0 end' "$SCENARIO_CONFIG")"
   min_recorded_sessions="$(jq -r --arg s "$scenario" --arg mode "$MODE" '.scenarios[] | select(.id == $s) | if $mode == "enforcement" then .enforcement_expected.min_recorded_sessions // 1 else .learning_expected.min_recorded_sessions // 1 end' "$SCENARIO_CONFIG")"
+  signal_process="$(jq -r --arg s "$scenario" '.scenarios[] | select(.id == $s) | .signal_process // ""' "$SCENARIO_CONFIG")"
 
   local sessions_file="$scenario_dir/sessions.log"
+  local sessions_flush_file="$scenario_dir/sessions_flush.log"
   local exceptions_file="$scenario_dir/exceptions.log"
   local summary_file="$scenario_dir/result_summary.json"
   local sessions_exit=0
 
+  # Flush sessions/exceptions caches before assertion. In practice, exceptions can be computed
+  # asynchronously, so we prefer to "warm" the cache and then retry get-exceptions briefly.
+  $EDAMAME_POSTURE_CMD get-sessions > "$sessions_flush_file" 2>&1 || true
+
+  local want_exceptions="false"
+  if [[ "$MODE" == "enforcement" && "$require_failure" == "true" ]]; then
+    want_exceptions="true"
+  fi
+  if [[ "$min_nonconforming" -gt 0 || "$min_anomalous" -gt 0 ]]; then
+    want_exceptions="true"
+  fi
+
+  if [[ "$want_exceptions" == "true" ]]; then
+    exceptions_ok="false"
+    for i in {1..8}; do
+      $EDAMAME_POSTURE_CMD get-exceptions > "$exceptions_file" 2>&1 || true
+      if [[ -n "$signal_process" ]]; then
+        if grep -F "process: Some(\"$signal_process\")" "$exceptions_file" 2>/dev/null | grep -qi 'whitelisted:[[:space:]]*\(nonconforming\|unknown\|anomalous\)'; then
+          exceptions_ok="true"
+          break
+        fi
+      else
+        if grep -qi 'whitelisted:[[:space:]]*\(nonconforming\|unknown\|anomalous\)' "$exceptions_file" 2>/dev/null; then
+          exceptions_ok="true"
+          break
+        fi
+      fi
+      sleep 2
+    done
+  else
+    $EDAMAME_POSTURE_CMD get-exceptions > "$exceptions_file" 2>&1 || true
+    exceptions_ok="true"
+  fi
+
   set +e
   if [[ "$MODE" == "enforcement" ]]; then
-    $EDAMAME_POSTURE_CMD get-sessions --fail-on-whitelist --fail-on-anomalous > "$sessions_file" 2>&1
+    # Keep enforcement deterministic: gate on explicit whitelist violations by default.
+    # If a scenario explicitly requires anomalous detection, it can set min_anomalous > 0.
+    ARGS=(get-sessions --fail-on-whitelist)
+    if [[ "$min_anomalous" -gt 0 ]]; then
+      ARGS+=(--fail-on-anomalous)
+    fi
+    $EDAMAME_POSTURE_CMD "${ARGS[@]}" > "$sessions_file" 2>&1
   else
     $EDAMAME_POSTURE_CMD get-sessions > "$sessions_file" 2>&1
   fi
   sessions_exit=$?
   set -e
 
-  $EDAMAME_POSTURE_CMD get-exceptions > "$exceptions_file" 2>&1 || true
+  local exceptions_signal_file
+  exceptions_signal_file="$exceptions_file"
+  if [[ -n "$signal_process" ]]; then
+    exceptions_signal_file="$scenario_dir/exceptions.signal.log"
+    grep -F "process: Some(\"$signal_process\")" "$exceptions_file" > "$exceptions_signal_file" 2>/dev/null || true
+  fi
 
-  local nonconforming_count anomalous_count unknown_count recorded_sessions
-  nonconforming_count="$(to_int "$(grep -ci 'whitelisted:[[:space:]]*nonconforming' "$sessions_file" 2>/dev/null || true)")"
-  anomalous_count="$(to_int "$(grep -ci 'anomalous' "$exceptions_file" 2>/dev/null || true)")"
-  unknown_count="$(to_int "$(grep -ci 'whitelisted:[[:space:]]*unknown' "$sessions_file" 2>/dev/null || true)")"
-  recorded_sessions="$(to_int "$(grep -cve '^[[:space:]]*$' "$sessions_file" 2>/dev/null || true)")"
+  local nonconforming_count anomalous_count unknown_count recorded_sessions active_whitelist
+  nonconforming_count="$(to_int "$(grep -ci 'whitelisted:[[:space:]]*nonconforming' "$exceptions_signal_file" 2>/dev/null || true)")"
+  unknown_count="$(to_int "$(grep -ci 'whitelisted:[[:space:]]*unknown' "$exceptions_signal_file" 2>/dev/null || true)")"
+  anomalous_count="$(to_int "$(grep -ci 'whitelisted:[[:space:]]*anomalous' "$exceptions_signal_file" 2>/dev/null || true)")"
+  recorded_sessions="$(to_int "$(grep -c '^[[]' "$sessions_file" 2>/dev/null || true)")"
+  active_whitelist="$($EDAMAME_POSTURE_CMD get-whitelist-name 2>/dev/null || echo "unknown")"
 
   local pass="true"
   local reason=()
@@ -250,6 +303,10 @@ collect_and_assert() {
   if [[ "$require_failure" == "true" && "$sessions_exit" -eq 0 ]]; then
     pass="false"
     reason+=("expected_nonzero_exit")
+  fi
+  if [[ "$want_exceptions" == "true" && "${exceptions_ok:-false}" != "true" ]]; then
+    pass="false"
+    reason+=("exceptions_unavailable")
   fi
   if [[ "$nonconforming_count" -lt "$min_nonconforming" ]]; then
     pass="false"
@@ -269,6 +326,8 @@ collect_and_assert() {
     --arg mode "$MODE" \
     --arg pass "$pass" \
     --arg reason "$(IFS=,; echo "${reason[*]:-ok}")" \
+    --arg signal_process "$signal_process" \
+    --arg active_whitelist "$active_whitelist" \
     --argjson sessions_exit "$sessions_exit" \
     --argjson nonconforming "$nonconforming_count" \
     --argjson anomalous "$anomalous_count" \
@@ -283,6 +342,8 @@ collect_and_assert() {
       pass: ($pass == "true"),
       reason: $reason,
       observed: {
+        signal_process: $signal_process,
+        active_whitelist: $active_whitelist,
         sessions_exit: $sessions_exit,
         nonconforming: $nonconforming,
         anomalous: $anomalous,

--- a/tests/run_adversarial_stability_lima.sh
+++ b/tests/run_adversarial_stability_lima.sh
@@ -51,6 +51,9 @@ done
 command -v limactl >/dev/null 2>&1 || fail "Missing limactl"
 command -v jq >/dev/null 2>&1 || fail "Missing jq"
 
+VM_REPO_DIR="$ROOT_DIR"
+VM_REPO_DIR_ESCAPED="$(printf '%q' "$VM_REPO_DIR")"
+
 IFS=',' read -r -a scenario_list <<< "$SCENARIOS"
 RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
 HOST_OUT_DIR="$ROOT_DIR/tests/artifacts/adversarial_stability_lima/$RUN_ID"
@@ -68,18 +71,26 @@ for iter in $(seq 1 "$ITERATIONS"); do
     log "Running scenario=$scenario"
 
     # Run scenario in VM; write artifacts to /tmp inside VM to avoid read-only mounts.
+    scenario_q="$(printf '%q' "$scenario")"
+    mode_q="$(printf '%q' "$MODE")"
+    remote_cmd="cd ${VM_REPO_DIR_ESCAPED} && ./tests/run_adversarial_lima.sh --scenario ${scenario_q} --mode ${mode_q} --output-dir /tmp/adversarial_local"
     if limactl shell "$VM_NAME" sudo -n /bin/bash -lc \
-      "cd '/Users/flyonnet/Programming/edamame_posture_action' && ./tests/run_adversarial_lima.sh --scenario '$scenario' --mode '$MODE' --output-dir /tmp/adversarial_local" \
+      "$remote_cmd" \
       >"$HOST_OUT_DIR/${iter}_${scenario}.stdout.log" 2>&1; then
       :
     fi
 
-    # Find most recent run directory in VM.
-    vm_latest="$(limactl shell "$VM_NAME" /bin/bash -lc "ls -1t /tmp/adversarial_local 2>/dev/null | head -1" 2>/dev/null || true)"
-    [[ -n "$vm_latest" ]] || fail "Could not find /tmp/adversarial_local runs in VM"
+    # Prefer the run directory emitted by the runner (more reliable than "latest").
+    run_dir="$(sed -n 's/^\\[adversarial\\] Evidence directory: //p' "$HOST_OUT_DIR/${iter}_${scenario}.stdout.log" | tail -1 || true)"
+    if [[ -n "${run_dir:-}" ]]; then
+      vm_summary_path="${run_dir}/${scenario}/result_summary.json"
+    else
+      vm_latest="$(limactl shell "$VM_NAME" /bin/bash -lc "ls -1t /tmp/adversarial_local 2>/dev/null | head -1" 2>/dev/null || true)"
+      [[ -n "$vm_latest" ]] || fail "Could not find /tmp/adversarial_local runs in VM"
+      vm_summary_path="/tmp/adversarial_local/${vm_latest}/${scenario}/result_summary.json"
+    fi
 
     # Fetch result summary to host for aggregation.
-    vm_summary_path="/tmp/adversarial_local/${vm_latest}/${scenario}/result_summary.json"
     summary_json="$(limactl shell "$VM_NAME" /bin/bash -lc "cat '$vm_summary_path' 2>/dev/null" 2>/dev/null || true)"
     if [[ -z "$summary_json" ]]; then
       # If the scenario failed before writing result_summary, record as fail.

--- a/tests/run_adversarial_suite_lima.sh
+++ b/tests/run_adversarial_suite_lima.sh
@@ -51,6 +51,9 @@ command -v jq >/dev/null 2>&1 || fail "Missing jq"
 CONFIG_JSON="$ROOT_DIR/tests/adversarial_scenarios.json"
 [[ -f "$CONFIG_JSON" ]] || fail "Missing scenario config: $CONFIG_JSON"
 
+VM_REPO_DIR="$ROOT_DIR"
+VM_REPO_DIR_ESCAPED="$(printf '%q' "$VM_REPO_DIR")"
+
 declare -a scenario_list=()
 if [[ "$SCENARIOS" == "all" ]]; then
   while IFS= read -r s; do scenario_list+=("$s"); done < <(jq -r '.scenarios[].id' "$CONFIG_JSON")
@@ -80,8 +83,11 @@ for scenario in "${scenario_list[@]}"; do
     log "Attempt $attempt/$((MAX_RETRIES + 1))"
 
     set +e
+    scenario_q="$(printf '%q' "$scenario")"
+    mode_q="$(printf '%q' "$MODE")"
+    remote_cmd="cd ${VM_REPO_DIR_ESCAPED} && ./tests/run_adversarial_lima.sh --scenario ${scenario_q} --mode ${mode_q} --output-dir /tmp/adversarial_local"
     limactl shell "$VM_NAME" sudo -n /bin/bash -lc \
-      "cd '/Users/flyonnet/Programming/edamame_posture_action' && ./tests/run_adversarial_lima.sh --scenario '$scenario' --mode '$MODE' --output-dir /tmp/adversarial_local" \
+      "$remote_cmd" \
       >"$OUT_DIR/${scenario}.stdout.log" 2>&1
     rc=$?
     set -e
@@ -94,11 +100,16 @@ for scenario in "${scenario_list[@]}"; do
     fi
 
     # Non-zero can mean test failure; still fetch result_summary if present.
-    vm_latest="$(limactl shell "$VM_NAME" /bin/bash -lc "ls -1t /tmp/adversarial_local 2>/dev/null | head -1" 2>/dev/null || true)"
-    if [[ -n "$vm_latest" ]]; then
-      vm_summary="/tmp/adversarial_local/${vm_latest}/${scenario}/result_summary.json"
-      limactl shell "$VM_NAME" /bin/bash -lc "cat '$vm_summary' 2>/dev/null" \
-        >"$OUT_DIR/${scenario}.result_summary.json" 2>/dev/null || true
+    run_dir="$(sed -n 's/^\\[adversarial\\] Evidence directory: //p' "$OUT_DIR/${scenario}.stdout.log" | tail -1 || true)"
+    if [[ -n "${run_dir:-}" ]]; then
+      vm_summary="${run_dir}/${scenario}/result_summary.json"
+      limactl shell "$VM_NAME" /bin/bash -lc "cat '$vm_summary' 2>/dev/null" >"$OUT_DIR/${scenario}.result_summary.json" 2>/dev/null || true
+    else
+      vm_latest="$(limactl shell "$VM_NAME" /bin/bash -lc "ls -1t /tmp/adversarial_local 2>/dev/null | head -1" 2>/dev/null || true)"
+      if [[ -n "$vm_latest" ]]; then
+        vm_summary="/tmp/adversarial_local/${vm_latest}/${scenario}/result_summary.json"
+        limactl shell "$VM_NAME" /bin/bash -lc "cat '$vm_summary' 2>/dev/null" >"$OUT_DIR/${scenario}.result_summary.json" 2>/dev/null || true
+      fi
     fi
 
     if [[ -f "$OUT_DIR/${scenario}.result_summary.json" ]] && jq -e '.pass == true' "$OUT_DIR/${scenario}.result_summary.json" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Make adversarial evasion scenarios prove real whitelist violations (no false pass from exit codes or background noise).
- Harden CI runner behavior: reliably create a non-empty custom whitelist, verify it is active, and upload evidence artifacts.
- Improve local Lima runners for transport resilience and deterministic result collection.

## Test Plan
- CI: `Test Adversarial Evasion Patterns` (workflow_dispatch, `gating_mode=strict`) run succeeded: https://github.com/edamametechnologies/edamame_posture_action/actions/runs/22125568691
- Local Lima: `./tests/run_adversarial_suite_lima.sh --scenarios dns_over_https,cdn_piggyback,process_masquerade`