### PR TITLE
v1.1.0: daemon-log dump, /var/log/edamame mode 1777, release-model SOTA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
           # Wait for the API to be ready
           wait_for_api: true
           packet_capture: true
+          vulnerability_detection: true
+          vulnerability_detection_interval: "60"
           agentic_mode: analyze
           agentic_provider: edamame
           agentic_interval: 600

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,6 @@ jobs:
           # Wait for the API to be ready
           wait_for_api: true
           packet_capture: true
-          vulnerability_detection: true
-          vulnerability_detection_interval: "60"
           agentic_mode: analyze
           agentic_provider: edamame
           agentic_interval: 600

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,76 +2,135 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Semver version to release (e.g. 1.1.0). Major must match the moving v1 tag."
+        required: true
+        type: string
 
-# Auto cancel previous runs if they were not completed.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
-# Write permissions are required to upload the release asset.
 permissions: write-all
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  build:
+  validate:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
-
+    timeout-minutes: 10
     steps:
-      - name: Setup EDAMAME Posture
-        uses: edamametechnologies/edamame_posture_action@v1
-        with:
-          edamame_user: ${{ vars.EDAMAME_POSTURE_USER }}
-          edamame_domain: ${{ vars.EDAMAME_POSTURE_DOMAIN }}
-          edamame_pin: ${{ secrets.EDAMAME_POSTURE_PIN }}
-          edamame_id: ${{ github.run_id }}
-          auto_remediate: true
-          network_scan: true
-          checkout: true
-          # Wait for the API to be ready
-          wait_for_api: true
-          packet_capture: true
-          vulnerability_detection: true
-          vulnerability_detection_interval: "60"
-          agentic_mode: analyze
-          agentic_provider: edamame
-          agentic_interval: 600
-        env:
-          EDAMAME_LLM_API_KEY: ${{ secrets.EDAMAME_LLM_API_KEY }}
-      # Set the release version
-      - name: Set Release Version
-        run: |
-          VERSION_TAG="v1"
-          echo "VERSION_TAG=${VERSION_TAG}" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
 
-      # Check if release exists and delete it if it does
-      - name: Clean up existing release
+      - name: Validate semver and major-version match
+        run: |
+          set -euo pipefail
+          v="${{ inputs.version }}"
+          if [[ ! "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Not semver (X.Y.Z): $v"
+            exit 1
+          fi
+          major="${v%%.*}"
+          if [[ "$major" != "1" ]]; then
+            echo "Major must be 1 (moving tag is v1); got $major"
+            exit 1
+          fi
+
+      - name: Validate version not already published
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Delete release but keep going even if it doesn't exist
-          gh release delete ${VERSION_TAG} --cleanup-tag --repo ${{ github.repository }} --yes || true
+          set -euo pipefail
+          if gh release view "v${{ inputs.version }}" --repo ${{ github.repository }} >/dev/null 2>&1; then
+            echo "Release v${{ inputs.version }} already exists. Bump version."
+            exit 1
+          fi
 
-      # Force update the v1 tag to current commit
-      - name: Update v1 tag
+      - name: Validate CHANGELOG has entry for this version
         run: |
-          git tag -f ${VERSION_TAG}
-          git push origin -f ${VERSION_TAG}
+          set -euo pipefail
+          if ! grep -qE "^## \[${{ inputs.version }}\]" CHANGELOG.md; then
+            echo "CHANGELOG.md missing [${{ inputs.version }}] entry"
+            exit 1
+          fi
 
-      # Create the release
-      - name: Create Release
-        uses: actions/create-release@v1
+      - name: Assert test.yml green on this SHA
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.VERSION_TAG }}
-          release_name: Release ${{ env.VERSION_TAG }}
-          draft: false
-          prerelease: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          conclusion=$(gh run list \
+            --repo ${{ github.repository }} \
+            --workflow test.yml \
+            --branch ${{ github.ref_name }} \
+            --commit ${{ github.sha }} \
+            --limit 1 \
+            --json conclusion --jq '.[0].conclusion // "missing"')
+          if [[ "$conclusion" != "success" ]]; then
+            echo "test.yml not green for SHA ${{ github.sha }} (got: $conclusion)."
+            echo "Push the change, wait for test.yml to complete on this SHA, then re-dispatch release."
+            exit 1
+          fi
 
-
-      - name: Dump EDAMAME Posture vulnerability findings
-        if: always()
-        uses: edamametechnologies/edamame_posture_action@v1
+  release:
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
         with:
-          dump_vulnerability_findings: true
-          exit_on_vulnerability_findings: true
+          fetch-depth: 0
+
+      - name: Tag immutable vX.Y.Z
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+
+      - name: Force-update moving v1 tag
+        run: |
+          set -euo pipefail
+          git tag -f v1
+          git push origin -f v1
+
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: |
+          set -euo pipefail
+          awk -v v="${{ inputs.version }}" '
+            $0 ~ "^## \\["v"\\]" {flag=1; next}
+            flag && /^## \[/ {exit}
+            flag {print}
+          ' CHANGELOG.md > /tmp/notes.md
+          if [[ ! -s /tmp/notes.md ]]; then
+            echo "Extracted release notes are empty -- check CHANGELOG.md formatting"
+            exit 1
+          fi
+          echo "--- extracted notes ---"
+          cat /tmp/notes.md
+          echo "--- end notes ---"
+
+      - name: Create GitHub Release for vX.Y.Z
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release create "v${{ inputs.version }}" \
+            --repo ${{ github.repository }} \
+            --title "Release v${{ inputs.version }}" \
+            --notes-file /tmp/notes.md \
+            --latest
+
+      - name: Refresh GitHub Release for v1 (moving)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release delete v1 --repo ${{ github.repository }} --yes 2>/dev/null || true
+          gh release create v1 \
+            --repo ${{ github.repository }} \
+            --title "v1 (moving) -> v${{ inputs.version }}" \
+            --notes "Currently points to [v${{ inputs.version }}](../releases/tag/v${{ inputs.version }})." \
+            --target ${{ github.sha }} \
+            --prerelease=false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ on:
       - 'main'
     paths:
       - 'action.yml'
+      - 'CHANGELOG.md'
+      - '.github/workflows/test.yml'
+      - '.github/workflows/release.yml'
       
 # Auto cancel previous runs if they were not completed.
 concurrency:
@@ -174,6 +177,30 @@ jobs:
           custom_whitelists_path: custom_whitelists.json
         continue-on-error: true
 
+      # Test display_logs collects daemon logs
+      - name: Test display_logs collects daemon logs
+        id: test-display-logs
+        uses: ./
+        with:
+          display_logs: true
+        continue-on-error: true
+
+      - name: Assert daemon log dump produced files
+        id: test-display-logs-assert
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${EDAMAME_DAEMON_LOGS_PATH:?EDAMAME_DAEMON_LOGS_PATH not set}"
+          [[ -d "$EDAMAME_DAEMON_LOGS_PATH" ]] || { echo "log dir missing"; exit 1; }
+          files=$(find "$EDAMAME_DAEMON_LOGS_PATH" -type f -name 'edamame_*' | wc -l)
+          if [[ "$files" -lt 1 ]]; then
+            echo "expected at least one daemon log, found $files"
+            ls -la "$EDAMAME_DAEMON_LOGS_PATH" || true
+            exit 1
+          fi
+          echo "OK: $files daemon log file(s) collected"
+        continue-on-error: true
+
       # Test stop
       - name: Test stop
         id: test-stop
@@ -240,6 +267,8 @@ jobs:
           (runner.os != 'Windows' && steps.test-create-custom-whitelist.outcome != 'success') || 
           (runner.os != 'Windows' && steps.test-set-custom-whitelist.outcome != 'success') ||
           (runner.os != 'Windows' && steps.test-augment-whitelist.outcome != 'success') ||
+          steps.test-display-logs.outcome != 'success' ||
+          steps.test-display-logs-assert.outcome != 'success' ||
           steps.test-stop.outcome != 'success' ||
           steps.test-disconnected-mode.outcome != 'success' ||
           steps.test-sessions-disconnected.outcome != 'success'
@@ -258,6 +287,8 @@ jobs:
             - Create Custom Whitelist: ${{ steps.test-create-custom-whitelist.outcome == 'success' && '✅ Success' || '❌ Failed' }}
             - Set Custom Whitelist: ${{ steps.test-set-custom-whitelist.outcome == 'success' && '✅ Success' || '❌ Failed' }}
             - Augment Whitelist: ${{ steps.test-augment-whitelist.outcome == 'success' && '✅ Success' || '❌ Failed' }}
+            - Display Logs Collect: ${{ steps.test-display-logs.outcome == 'success' && '✅ Success' || '❌ Failed' }}
+            - Display Logs Assert: ${{ steps.test-display-logs-assert.outcome == 'success' && '✅ Success' || '❌ Failed' }}
             - Disconnected Mode: ${{ steps.test-disconnected-mode.outcome == 'success' && '✅ Success' || '❌ Failed' }}
             - Sessions Disconnected: ${{ steps.test-sessions-disconnected.outcome == 'success' && '✅ Success' || '❌ Failed' }}
             Branch: ${{ github.ref }}
@@ -277,6 +308,8 @@ jobs:
           (runner.os != 'Windows' && steps.test-create-custom-whitelist.outcome != 'success') || 
           (runner.os != 'Windows' && steps.test-set-custom-whitelist.outcome != 'success') ||
           (runner.os != 'Windows' && steps.test-augment-whitelist.outcome != 'success') ||
+          steps.test-display-logs.outcome != 'success' ||
+          steps.test-display-logs-assert.outcome != 'success' ||
           steps.test-stop.outcome != 'success' ||
           steps.test-disconnected-mode.outcome != 'success' ||
           steps.test-sessions-disconnected.outcome != 'success'
@@ -292,6 +325,8 @@ jobs:
           echo "- Create Custom Whitelist: ${{ steps.test-create-custom-whitelist.outcome == 'success' && '✅ Success' || '❌ Failed' }}"
           echo "- Set Custom Whitelist: ${{ steps.test-set-custom-whitelist.outcome == 'success' && '✅ Success' || '❌ Failed' }}"
           echo "- Augment Whitelist: ${{ steps.test-augment-whitelist.outcome == 'success' && '✅ Success' || '❌ Failed' }}"
+          echo "- Display Logs Collect: ${{ steps.test-display-logs.outcome == 'success' && '✅ Success' || '❌ Failed' }}"
+          echo "- Display Logs Assert: ${{ steps.test-display-logs-assert.outcome == 'success' && '✅ Success' || '❌ Failed' }}"
           echo "- Disconnected Mode: ${{ steps.test-disconnected-mode.outcome == 'success' && '✅ Success' || '❌ Failed' }}"
           echo "- Sessions Disconnected: ${{ steps.test-sessions-disconnected.outcome == 'success' && '✅ Success' || '❌ Failed' }}"
           echo "- Stop: ${{ steps.test-stop.outcome == 'success' && '✅ Success' || '❌ Failed' }}"

--- a/.github/workflows/test_vulnerability_gate.yml
+++ b/.github/workflows/test_vulnerability_gate.yml
@@ -238,6 +238,31 @@ jobs:
             python3 "$TRIGGERS_DIR/cleanup.py" --agent-type openclaw || true
           fi
 
+      # The token_exfil trigger above deliberately fires a
+      # `HIGH`/`CRITICAL` vulnerability finding so we can verify the gate
+      # actually trips. That finding is persisted in
+      # `agentic_config.json`; if this job ever runs on a self-hosted
+      # runner (or the runner is reused with stale state) the finding
+      # would leak into the next job's runner-protection gate. Clear the
+      # vulnerability history before stopping the daemon so the on-disk
+      # state is clean.
+      - name: Clear runtime vulnerability state (test artifacts)
+        if: always()
+        shell: bash
+        run: |
+          # Install edamame_cli on demand (small static binary).
+          if ! command -v edamame_cli >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf \
+              https://raw.githubusercontent.com/edamametechnologies/edamame_cli/main/install.sh \
+              | sudo -E sh -s -- || {
+              echo "edamame_cli install failed; skipping runtime cleanup."
+              exit 0
+            }
+          fi
+          echo "Clearing all runtime vulnerability findings (test scenarios)..."
+          edamame_cli rpc clear_vulnerability_history || true
+          edamame_cli rpc reset_vulnerability_suppressions || true
+
       - name: Stop posture daemon
         if: always()
         uses: ./

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,90 @@
+# Changelog
+
+All notable changes to this GitHub Action are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The moving major-version tag (`v1`) is force-updated to the latest
+backwards-compatible release on every cut. Immutable `vX.Y.Z` tags are
+also published for reproducible pins; see the README "Pinning" section.
+
+## [Unreleased]
+
+## [1.1.0] - 2026-05-14
+
+### Fixed
+
+- `display_logs: true` now correctly dumps the daemon's rolling log files
+  from `/var/log/edamame/edamame_*_<pid>.YYYY-MM-DD` (Unix) and the
+  binary's parent directory (Windows). Previously the step did
+  `cd ~ && find .` which missed `/var/log/edamame/` entirely and had no
+  `sudo`, so it could not read the daemon's root-owned rolling logs.
+- Pre-create `/var/log/edamame` mode `1777` (sticky world-writable, like
+  `/tmp`) on Unix so non-`sudo` CLI invocations no longer print
+  `Failed to initialize rolling file appender in /var/log/edamame: Permission denied`.
+  Both the root daemon and non-`sudo` CLI processes can now write their
+  PID-suffixed log files in the same directory.
+
+### Added
+
+- `EDAMAME_DAEMON_LOGS_PATH` environment variable, exported when
+  `display_logs: true`, points to `$RUNNER_TEMP/edamame-daemon-logs/`.
+  Downstream `actions/upload-artifact` steps can hand the path through
+  directly without recomputing daemon paths or trusting the daemon PID.
+  See README "Daemon log collection".
+- `dump_vulnerability_findings: true` now also runs
+  `vulnerability-findings --active-only` (when the installed
+  `edamame_posture` exposes the subcommand, > 1.2.2) and prints the full
+  per-finding data (`finding_key`, `check`, `severity`, `description`,
+  `process_*`, `destination_*`, `open_files`, `detection_basis`) so a CI
+  operator can triage a finding from the job log alone without SSHing
+  into the runner. Older posture binaries gracefully fall through with
+  an `[INFO]` note; the summary-count gate path is unchanged.
+- README "Pinning" subsection explaining the difference between the
+  moving `@v1` tag and immutable `@vX.Y.Z` tags.
+- New release-time validation: the `release.yml` workflow now gates on
+  `test.yml` being green on the same commit, semver-shape, and the
+  presence of a CHANGELOG entry for the dispatched version.
+
+### Improved
+
+- The vulnerability gate's Python fallback (used when the installed
+  `edamame_posture` does not expose `--fail-on-findings`) now prefers
+  `active_alertable_findings` (HIGH/CRITICAL non-dismissed) over the raw
+  `active_findings` total, mirroring the native flag introduced in
+  `edamame_posture` v1.3.1. LOW-severity ambient findings (CI
+  bootstrappers like `rustup-init` from `/tmp/`, benign temp `.log`
+  writes) stay visible in the dashboard but no longer trip the run gate.
+  Older daemons that predate the alertable counter fall back to
+  `active_findings` so the gate keeps working during a rolling upgrade.
+- Self-test workflow `test_vulnerability_gate.yml` now clears runtime
+  vulnerability state (`clear_vulnerability_history` +
+  `reset_vulnerability_suppressions`) after the gate-firing scenario, so
+  the deliberately-injected token-exfil finding cannot leak into a
+  subsequent workflow run on the same self-hosted runner per the
+  `vulnerability_detector` Finding Persistence invariant.
+
+### Changed
+
+- `release.yml` now publishes BOTH an immutable `vX.Y.Z` tag plus a
+  GitHub Release AND force-updates the moving `v1` tag and its release
+  pointer. The previous workflow only force-updated `v1`.
+- `test.yml` `paths:` trigger now also fires on changes to
+  `CHANGELOG.md`, `.github/workflows/test.yml`, and
+  `.github/workflows/release.yml` so a release-relevant commit always
+  produces a green test run on its own SHA before the release gate
+  evaluates it.
+- `release.yml` no longer dogfoods the action in-line (no more
+  `Setup Posture` + `dump_vulnerability_findings` steps in the release
+  workflow itself); the runner-protection gate is exercised by
+  `test.yml` and `test_vulnerability_gate.yml`. This also removes the
+  chicken-and-egg of `release.yml` consuming `@v1` while the release
+  is mid-flight.
+
+## [1.0.0] - 2026-04-17
+
+- Initial immutable-tag release (commit 479ee93).
+- Composite action covering: setup, network scan, packet capture,
+  policy checks, custom and auto-whitelist lifecycle, runtime
+  vulnerability gate, eBPF support verification, and stop.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ jobs:
           exit_on_vulnerability_findings: true
 ```
 
-The final step prints the detector status and fails the workflow when `active_findings` is greater than zero.
+The final step prints the detector status and fails the workflow when there are active **alertable** findings (HIGH or CRITICAL severity, non-dismissed). The action prefers `active_alertable_findings` from the daemon when available so LOW-severity ambient findings (e.g. CI bootstrappers like `rustup-init` running from `/tmp/`, build scripts writing benign `.log` artifacts) stay visible in the dashboard for operator triage without by themselves failing the run. Older daemons that predate the alertable counter fall back to the raw `active_findings` total.
 
 ## Installation Behavior
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ Harden GitHub Actions runners and continuously verify runtime/network behavior t
 
 For the broader “Zero Trust at the GitHub layer” framing (identity + device + context, continuous verification per request), see: https://www.edamame.tech/zerotrust-github
 
+### Pinning
+
+- Default: `uses: edamametechnologies/edamame_posture_action@v1`. Picks up
+  the latest backwards-compatible v1 release automatically. Recommended
+  for most users.
+- Reproducible: `uses: edamametechnologies/edamame_posture_action@v1.1.0`.
+  Pinned to an immutable tag. Recommended for release-critical
+  workflows where you need byte-identical action behavior across runs.
+
+The release workflow publishes both tags on every cut: a fresh
+immutable `vX.Y.Z` tag plus a force-updated `v1` pointing to the same
+commit. See [`CHANGELOG.md`](CHANGELOG.md) for the version history.
+
 ## Overview
 This GitHub Action sets up and configures [EDAMAME Posture](https://github.com/edamametechnologies/edamame_posture), the CLI for runner and build-host trust gates, posture checks, and optional runtime network enforcement.
 It supports Windows, Linux, and macOS runners, checking for and installing any missing dependencies such as wget, curl, jq, Node.js, etc.
@@ -116,6 +129,36 @@ jobs:
 ```
 
 The final step prints the detector status and fails the workflow when there are active **alertable** findings (HIGH or CRITICAL severity, non-dismissed). The action prefers `active_alertable_findings` from the daemon when available so LOW-severity ambient findings (e.g. CI bootstrappers like `rustup-init` running from `/tmp/`, build scripts writing benign `.log` artifacts) stay visible in the dashboard for operator triage without by themselves failing the run. Older daemons that predate the alertable counter fall back to the raw `active_findings` total.
+
+For postmortem of a wedged daemon (e.g. an integration test that hung and tripped the gate), set `display_logs: true` in the same end-of-job invocation. See [Daemon log collection](#daemon-log-collection) below for the upload pattern.
+
+## Daemon log collection
+
+When `display_logs: true` is set, the action dumps every EDAMAME daemon log file (`/var/log/edamame/edamame_*_<pid>.YYYY-MM-DD` on Linux/macOS, the binary's parent directory on Windows) into the job log AND copies the same files to a stable directory under `$RUNNER_TEMP`. The directory path is exported as the `EDAMAME_DAEMON_LOGS_PATH` env var so a downstream step can hand it to `actions/upload-artifact` without having to recompute paths or trust the daemon's PID.
+
+Pattern:
+
+```yaml
+      - name: Stop on runtime vulnerability findings
+        uses: edamametechnologies/edamame_posture_action@v1
+        with:
+          dump_vulnerability_findings: true
+          exit_on_vulnerability_findings: true
+          display_logs: true
+
+      - name: Upload EDAMAME daemon logs
+        if: always() && env.EDAMAME_DAEMON_LOGS_PATH != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: edamame-daemon-logs-${{ github.job }}
+          path: ${{ env.EDAMAME_DAEMON_LOGS_PATH }}
+          if-no-files-found: ignore
+```
+
+Notes:
+- The action pre-creates `/var/log/edamame` with mode `1777` on Unix runners, so both the root daemon and non-`sudo` CLI invocations can write their PID-suffixed log files without "Permission denied" warnings.
+- Each file is tail-capped at 2 MB in the job log to keep the run page responsive; the raw file in `EDAMAME_DAEMON_LOGS_PATH` is uncapped.
+- If no daemon ever started in this job (e.g. the action only ran in `stop` or dump mode and the daemon was never up), the directory exists but may be empty -- `if-no-files-found: ignore` keeps that from failing the upload.
 
 ## Installation Behavior
 
@@ -236,7 +279,7 @@ The action sets `EDAMAME_POSTURE_CMD` based on the installation method and envir
 - `wait`: Wait for a while (180 seconds) (default: false)  
 - `wait_for_api`: Wait for API access via the GitHub CLI (default: false)  
 - `token`: GitHub token to checkout the repo (default: ${{ github.token }})  
-- `display_logs`: Display posture logs (default: false)  
+- `display_logs`: Dump the EDAMAME daemon's rolling log files (`/var/log/edamame/edamame_*_<pid>.YYYY-MM-DD` on Unix, beside the binary on Windows) to the job log AND copy them to `$RUNNER_TEMP/edamame-daemon-logs/`. The path is exported as `EDAMAME_DAEMON_LOGS_PATH` for downstream `actions/upload-artifact` steps. See [Daemon log collection](#daemon-log-collection) for an upload example. (default: false)  
 - `debug`: Enable debug mode - downloads debug version of binary and sets log level to debug (default: false)  
 - `get_device_info`: Display device info including eBPF support status. Linux only (default: false)
 - `verify_ebpf`: Verify eBPF is properly embedded in the binary. Fails if eBPF was not compiled in (build failure). Runtime restrictions (kernel settings, containers) are acceptable and won't fail. Implies `get_device_info=true`. Linux only (default: false)
@@ -382,8 +425,10 @@ Some GitHub organizations enforce IP allow lists that block unauthenticated arti
 1. **Upload artifacts**  
    - Uploads auto-whitelist files to GitHub artifacts for next run
 
-1. **Display posture logs**  
-   - If `display_logs` is true, prints the EDAMAME daemon logs
+1. **Collect EDAMAME daemon logs**  
+   - If `display_logs` is true, dumps the daemon's rolling logs (`/var/log/edamame/edamame_*_<pid>.YYYY-MM-DD` on Unix, beside the binary on Windows) to the job log
+   - Copies the same files to `$RUNNER_TEMP/edamame-daemon-logs/` and exports the path as `EDAMAME_DAEMON_LOGS_PATH`
+   - Suitable for downstream `actions/upload-artifact` consumption (see [Daemon log collection](#daemon-log-collection))
 
 1. **Create custom whitelist**  
    - If `create_custom_whitelists` is true, generates a whitelist from the current network sessions.

--- a/action.yml
+++ b/action.yml
@@ -4174,6 +4174,28 @@ runs:
         set -euo pipefail
         cd
         STATUS_FILE="${RUNNER_TEMP:-/tmp}/edamame_vulnerability_status.json"
+        FINDINGS_FILE="${RUNNER_TEMP:-/tmp}/edamame_vulnerability_findings.json"
+
+        # Best-effort: dump per-finding details (finding_key, check, severity,
+        # description, process_*, destination_*, open_files, detection_basis)
+        # via the `vulnerability-findings` subcommand. This subcommand was
+        # added in edamame_posture > 1.2.2; older binaries don't expose it
+        # and the call falls through with a stderr warning. Either way the
+        # gate logic below uses `vulnerability-status` which is universally
+        # available.
+        echo "Executing: $EDAMAME_POSTURE_CMD vulnerability-findings --active-only"
+        set +e
+        $EDAMAME_POSTURE_CMD vulnerability-findings --active-only 2>&1 | tee "$FINDINGS_FILE"
+        findings_rc=${PIPESTATUS[0]}
+        set -e
+        if [[ $findings_rc -ne 0 ]]; then
+          if grep -qiE '(unrecognized subcommand|unexpected argument|unknown argument|usage:|invalid value)' "$FINDINGS_FILE"; then
+            echo "[INFO] Installed edamame_posture does not expose 'vulnerability-findings'; per-finding details are unavailable until the next posture release. The summary count below is still reliable."
+          else
+            echo "[WARN] vulnerability-findings call failed with rc=$findings_rc; continuing with summary-only output."
+          fi
+        fi
+
         if [[ "${{ inputs.exit_on_vulnerability_findings }}" == "true" ]]; then
           echo "Executing: $EDAMAME_POSTURE_CMD vulnerability-status --fail-on-findings"
           set +e

--- a/action.yml
+++ b/action.yml
@@ -4221,7 +4221,16 @@ runs:
         with open(sys.argv[1], "r", encoding="utf-8") as fh:
             data = json.load(fh)
 
-        print(int(data.get("active_findings") or 0))
+        # Prefer the alertable count (HIGH/CRITICAL only) when the daemon
+        # exposes it. LOW severity findings (e.g. ambient `spawned_from_tmp`
+        # signals from CI bootstrappers like rustup-init or cargo install)
+        # remain visible in the dashboard but do not by themselves indicate
+        # an actionable runtime compromise. Older daemons that do not yet
+        # emit this field fall back to the raw `active_findings` total.
+        if data.get("active_alertable_findings") is not None:
+            print(int(data.get("active_alertable_findings") or 0))
+        else:
+            print(int(data.get("active_findings") or 0))
         PY
         )"
           echo "Active vulnerability findings: $active_findings"

--- a/action.yml
+++ b/action.yml
@@ -226,7 +226,7 @@ inputs:
     required: false
     default: "false"
   display_logs:
-    description: "Display logs"
+    description: "Dump the EDAMAME daemon's rolling log files (/var/log/edamame/edamame_*_<pid>.YYYY-MM-DD on Unix, beside the binary on Windows) to the job log AND copy them to $RUNNER_TEMP/edamame-daemon-logs/. Path is exported as EDAMAME_DAEMON_LOGS_PATH for downstream actions/upload-artifact steps."
     required: false
     default: "false"
   debug:
@@ -557,6 +557,13 @@ runs:
           exit 1
         fi
       shell: bash
+
+    - name: Pre-create EDAMAME log directory (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        sudo mkdir -p /var/log/edamame
+        sudo chmod 1777 /var/log/edamame
 
     - name: Install or Update EDAMAME Posture
       id: install_posture
@@ -4425,15 +4432,41 @@ runs:
       env:
         EDAMAME_POSTURE_CMD: ${{ env.EDAMAME_POSTURE_CMD }}
 
-    - name: Display logs if requested
-      run: |
-        if [[ "${{ inputs.display_logs }}" == "true" ]]; then
-          # Rather scan the home directory for logs in case the dameon has been killed
-          cd
-          #$EDAMAME_POSTURE_CMD logs
-          find . \( -name "edamame_*.2*-*-*" -o -name "*_panic_*.txt" \) -exec echo "--- {} ---" \; -exec cat {} \; || echo "No logs found"
-        fi
+    - name: Collect EDAMAME daemon logs if requested
+      if: ${{ inputs.display_logs == 'true' }}
       shell: bash
+      run: |
+        set +e
+        LOG_DEST="${RUNNER_TEMP:-/tmp}/edamame-daemon-logs"
+        mkdir -p "$LOG_DEST"
+        case "$RUNNER_OS" in
+          Linux|macOS)
+            if [[ -d /var/log/edamame ]]; then
+              sudo cp -a /var/log/edamame/. "$LOG_DEST/" 2>/dev/null || true
+              sudo chmod -R a+r "$LOG_DEST" 2>/dev/null || true
+            fi
+            # Fallback: catch files left in $HOME (logger fallback path)
+            cd
+            find . -maxdepth 2 \( -name "edamame_*.2*-*-*" -o -name "*_panic_*.txt" \) \
+              -exec cp {} "$LOG_DEST/" \; 2>/dev/null || true
+            ;;
+          Windows)
+            BIN_DIR=$(dirname "${EDAMAME_BINARY_PATH:-}")
+            if [[ -n "$BIN_DIR" && -d "$BIN_DIR" ]]; then
+              find "$BIN_DIR" -maxdepth 1 -type f \
+                \( -name 'edamame_*_*.2*-*-*' -o -name '*_panic_*.txt' \) \
+                -print0 | xargs -0 -I {} cp "{}" "$LOG_DEST/" 2>/dev/null || true
+            fi
+            ;;
+        esac
+        echo "EDAMAME_DAEMON_LOGS_PATH=$LOG_DEST" >> "$GITHUB_ENV"
+        echo "--- /var/log/edamame contents ---"
+        [[ "$RUNNER_OS" != "Windows" ]] && (sudo ls -la /var/log/edamame/ 2>/dev/null || true)
+        echo "--- daemon log dump (capped at 2MB/file) ---"
+        find "$LOG_DEST" -type f \
+          -exec echo "=== {} ===" \; \
+          -exec tail -c 2000000 {} \; 2>/dev/null || true
+        echo "--- end daemon log dump ---"
 
     - name: Save auto-whitelist state
       if: ${{ inputs.dump_sessions_log == 'true' && env.AUTO_WHITELIST_ENABLED == 'true' }}


### PR DESCRIPTION
## Summary

- **`display_logs: true` actually works now.** The previous step did `cd ~ && find .` which missed `/var/log/edamame/` (where the daemon's rolling logs land) and had no `sudo`. Replaced with a step that copies `/var/log/edamame/.` on Unix, falls back to `$HOME` for any logger-fallback files, handles the Windows binary-dir path, dumps each file to the job log capped at 2 MB, and exports the dest directory as `EDAMAME_DAEMON_LOGS_PATH` for downstream `actions/upload-artifact` consumption.
- **`/var/log/edamame` is pre-created mode `1777`** (sticky world-writable, like `/tmp`) right after the `Dependencies` step. The "Failed to initialize rolling file appender in /var/log/edamame: Permission denied" warning from non-`sudo` CLI invocations is gone; both the root daemon and non-root CLI processes can write their PID-suffixed log files in the same dir.
- **Release-model SOTA.** `release.yml` is rewritten as `validate` + `release` jobs. `validate` enforces semver shape, major == 1, version not already published, CHANGELOG entry present, and `test.yml` green on the dispatched SHA. `release` tags an immutable `vX.Y.Z`, force-updates moving `v1`, and publishes BOTH GitHub Releases with notes extracted from `CHANGELOG.md`.
- **Backwards compatible.** All consumers pinned to `@v1` continue to work; the daemon-log dump is a strict superset of the broken old behavior; the alertable-findings parser already in this branch falls back to `active_findings` for older daemons.
- **`test.yml` self-checks the dump.** New `Test display_logs collects daemon logs` + assertion step in the `test-native` matrix asserts `EDAMAME_DAEMON_LOGS_PATH` is set, the directory exists, and at least one `edamame_*` file was collected. Wired into Slack alert and the final fail-summary so silent regressions of `v1` get caught.
- **`paths:` trigger expanded** to include `CHANGELOG.md`, `.github/workflows/test.yml`, `.github/workflows/release.yml` so any release-relevant commit on `main` re-runs the matrix.
- **Also rolling under v1.1.0** (already in this branch): per-finding vulnerability dump (`vulnerability-findings --active-only`, falls through gracefully on older daemons), gate Python fallback prefers `active_alertable_findings` (HIGH/CRITICAL only), `test_vulnerability_gate.yml` clears runtime vuln state after the gate-firing scenario.

See [`CHANGELOG.md`](CHANGELOG.md) `[1.1.0]` for the full set.

## Test plan

- [x] `yaml.safe_load` parses `action.yml`, `test.yml`, `release.yml` cleanly.
- [x] Release-notes `awk` extractor produces clean output for `v=1.1.0` and terminates at `[1.0.0]`.
- [ ] `test.yml` (manually dispatched on this branch, run [25853527336](https://github.com/edamametechnologies/edamame_posture_action/actions/runs/25853527336)) green on `bab4559` — including the new `Test display_logs collects daemon logs` + `Assert daemon log dump produced files` steps.
- [ ] After merge, `test.yml` auto-runs on the merge SHA on `main` (paths filter matches everything in this PR).
- [ ] `gh workflow run release.yml --ref main -f version=1.1.0` from a clean main; `validate` job passes; `release` job creates `v1.1.0` immutable tag, force-updates `v1`, publishes both GitHub Releases.
- [ ] Verify on GitHub: `v1.1.0` annotated tag points at the merge SHA, `v1` lightweight tag points at the same SHA, "Latest" Release is `v1.1.0`, `v1` Release body links to `v1.1.0`.